### PR TITLE
Fix URLs in documentation after repo transfer to KnightSoft

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ basis for your own powerful operating systems.
 
 ## Building KnightOS
 
-Precomiled packages are not currently being distributed. However, you may build KnightOS from
+Precompiled packages are not currently being distributed. However, you may build KnightOS from
 its source yourself. From a command line, navigate to the build directory. On Windows, run
 `build --all` to build KnightOS for all calculators. On Linux/Mac, install Mono. Then, run
 `mono build.exe --all`. You may want to change some details in `inc/config.asm` to customize
@@ -18,7 +18,7 @@ Once the build completes, look in `bin/` for the completed OS upgrade files, whi
 and ready to send to a calculator. ROM files will also be generated for use in emulators.
 
 For details on advanced usage of the build tool, see
-[its documentation](https://github.com/SirCmpwn/KnightOS/blob/master/docs/build/build-tool.md).
+[its documentation](https://github.com/KnightSoft/KnightOS/blob/master/docs/build/build-tool.md).
 This documentation includes details on building for specific platforms, and targetting
 languages other than English.
 
@@ -56,7 +56,7 @@ KnightOS on those devices.
 **NOTE**: Newer versions of the TI-84+, TI-84+ SE, and all TI-84 Pocket.fr and TI-84 Plus Pocket SE
 calculators are shipped with boot code 1.03, which prevents the installation of 3rd party operating
 systems. You must patch these calculators before you will be able to install KnightOS on them.
-Instructions for doing so may be found [here](https://github.com/SirCmpwn/KnightOS/tree/master/boot-patch).
+Instructions for doing so may be found [here](https://github.com/KnightSoft/KnightOS/tree/master/boot-patch).
 
 ## Help, Bugs, Feedback
 
@@ -64,5 +64,5 @@ If you need help with KnightOS, want to keep up with progress, chat with develop
 ask any other questions about KnightOS, you can drop by the IRC channel: [#knightos on
 irc.freenode.net](http://webchat.freenode.net/?channels=knightos).
 
-To report bugs, please create [a GitHub issue](https://github.com/SirCmpwn/KnightOS/issues/new)
+To report bugs, please create [a GitHub issue](https://github.com/KnightOS/KnightOS/issues/new)
 or contact us on IRC.

--- a/boot-patch/README.md
+++ b/boot-patch/README.md
@@ -19,7 +19,7 @@ That being said, such a scenario is extremely unlikely, but proceed at your own 
 
 ## Instructions
 
-Please download [patch.8xp](https://github.com/SirCmpwn/KnightOS/tree/master/boot-patch/patch.8xp)
+Please download [patch.8xp](https://github.com/KnightSoft/KnightOS/tree/master/boot-patch/patch.8xp)
 and transfer it to your calcultor with TI-Connect, TILP, or a similar program. When the transfer
 completes, do the following from the home screen:
 

--- a/docs/build/build-tool.md
+++ b/docs/build/build-tool.md
@@ -8,7 +8,7 @@ The build tool is a .NET tool written in C# to assist in building KnightOS from 
 * Create the kernel jump table and include files
 * Create the base filesystem and import the userspace files
 
-The source code for the build tool may be found in [build/tool/](https://github.com/SirCmpwn/KnightOS/tree/master/build/tool/).
+The source code for the build tool may be found in [build/tool/](https://github.com/KnightSoft/KnightOS/tree/master/build/tool/).
 
 ## Usage
 
@@ -23,7 +23,7 @@ with no parameters, is to build the TI-84+ Silver Edition version in English. Yo
     --verbose: Output all sass output to the console.
 
 ### Configurations
-    
+
 The possible configuration values are the following:
 
 * TI73
@@ -35,7 +35,7 @@ The possible configuration values are the following:
 *Note*: Providing --all will build all of these configurations, in this order.
 
 The tool will use the appropriate signing key based on this selection, as well as defining the configuration value at assembly
-time. [inc/defines.inc](https://github.com/SirCmpwn/KnightOS/blob/master/inc/defines.inc) will add additional defined values
+time. [inc/defines.inc](https://github.com/KnightSoft/KnightOS/blob/master/inc/defines.inc) will add additional defined values
 at assembly time based on the configuration value. The default value is TI84pSE.
 
 KnightOS does not use the same binary to target all platforms. For the sake of optimization, a different binary is distributed
@@ -43,7 +43,7 @@ for each target platform.
 
 ### Languages
 
-The language selection is the name of a folder in [lang/](https://github.com/SirCmpwn/KnightOS/blob/master/lang/). This folder
+The language selection is the name of a folder in [lang/](https://github.com/KnightSoft/KnightOS/blob/master/lang/). This folder
 will be added to the include path for sass, and "lang_[language]" will be defined at assembly time. The default is en_us.
 
 ## Build Files
@@ -103,17 +103,17 @@ process. The following commands are available:
 * pages \[hex...]: Adds the specified pages, in hex, to the final 8xu or 73u files.
 * rm \[targets...]: Deletes \[targets...], either files or directories.
 
-The build tool will first build [src/kernel/build.cfg](https://github.com/SirCmpwn/KnightOS/blob/master/src/kernel/build.cfg), then
-[src/userspace/build.cfg](https://github.com/SirCmpwn/KnightOS/blob/master/src/userspace/build.cfg).
+The build tool will first build [src/kernel/build.cfg](https://github.com/KnightSoft/KnightOS/blob/master/src/kernel/build.cfg), then
+[src/userspace/build.cfg](https://github.com/KnightSoft/KnightOS/blob/master/src/userspace/build.cfg).
 
 ## Include Files
 
-sass will be instructed to add [inc/](https://github.com/SirCmpwn/KnightOS/blob/master/inc/) to the include path, as well as the
-selected language folder in [lang/](https://github.com/SirCmpwn/KnightOS/blob/master/lang/).
+sass will be instructed to add [inc/](https://github.com/KnightSoft/KnightOS/blob/master/inc/) to the include path, as well as the
+selected language folder in [lang/](https://github.com/KnightSoft/KnightOS/blob/master/lang/).
 
 ## Output
 
 The build tool outputs the final files to `bin/<configuration>/KnightOS-<locale>.[rom|8xu|73u]`.
 
-8xu and 73u files are signed with one of the keys in [build/](https://github.com/SirCmpwn/KnightOS/blob/master/build/), based on
+8xu and 73u files are signed with one of the keys in [build/](https://github.com/KnightSoft/KnightOS/blob/master/build/), based on
 the configuration value.

--- a/docs/build/userspace.md
+++ b/docs/build/userspace.md
@@ -5,9 +5,9 @@ page 0, and is perpetually swapped in to bank 0. The filesystem is the remainder
 pages of the filesystem are swapped into bank 1 to facilitate reading and writing with it.
 
 To build userspace, the build tool reads the
-[userspace configuration](https://github.com/SirCmpwn/KnightOS/blob/master/src/userspace/build.cfg).
+[userspace configuration](https://github.com/KnightSoft/KnightOS/blob/master/src/userspace/build.cfg).
 This file instructs it to build several files in
-[src/userspace/](https://github.com/SirCmpwn/KnightOS/blob/master/docs/build/build-tool.md) and copy
+[src/userspace/](https://github.com/KnightSoft/KnightOS/blob/master/docs/build/build-tool.md) and copy
 them to src/out/. src/userspace/ is organized in a similar manner to how it appears in the final
 filesystem. Once all files are assembled and copied, src/userspace/out/ becomes the root folder of
 the filesystem installed on the final binaries.
@@ -34,4 +34,4 @@ Ensure that you remove extraneous files, such as .lab and .lst files.
 ## Adding to the Castle
 
 If you want your program to appear in the castle, you need to update
-[src/userspace/etc/castle.config](https://github.com/SirCmpwn/KnightOS/blob/master/src/userspace/etc/castle.config.asm).
+[src/userspace/etc/castle.config](https://github.com/KnightSoft/KnightOS/blob/master/src/userspace/etc/castle.config.asm).

--- a/docs/kernel/general/bcall.md
+++ b/docs/kernel/general/bcall.md
@@ -7,7 +7,7 @@ you try to execute a TIOS program). However, you can override this behavior as a
 If you wish to provide a compatibility layer of some sort, you can handle bcalls yourself.
 
 The code for the system handler is in
-[src/kernel/00/restarts.asm](https://github.com/SirCmpwn/KnightOS/blob/master/src/kernel/00/restarts.asm).
+[src/kernel/00/restarts.asm](https://github.com/KnightSoft/KnightOS/blob/master/src/kernel/00/restarts.asm).
 
 Use of the system bcall hook is simple. Here's an example:
 
@@ -15,15 +15,15 @@ Use of the system bcall hook is simple. Here's an example:
         #include "defines.inc"
         #include "kernel.inc"
         #include "stdio.inc"
-        
+
         kld(hl, hook)
         ld (bcallHook), hl
-        
+
         ; Do a bcall
         rst $28
         .dw $1234
         ret
-        
+
     hook:
         kld(hl, text)
         stdio(printline)
@@ -34,11 +34,11 @@ Use of the system bcall hook is simple. Here's an example:
         ; Increment past the .dw (we don't actually handle bcalls here)
         inc hl \ inc hl
         push hl
-        
+
         dec sp \ dec sp
         pop hl ; Restore HL
         ret
-    
+
     text:
         .asciiz "bcall executed!"
 

--- a/docs/kernel/general/memory.md
+++ b/docs/kernel/general/memory.md
@@ -17,7 +17,7 @@ It is laid out as follows:
     <tr><td>0x8200</td><td>0x7E00</td><td>Userspace memory</td></tr>
 </table>
 
-<em>* See <a href="https://github.com/SirCmpwn/KnightOS/blob/master/inc/defines.inc#L66">defines.inc</a> for details</em>
+<em>* See <a href="https://github.com/KnightSoft/KnightOS/blob/master/inc/defines.inc#L66">defines.inc</a> for details</em>
 
 Kernel garbage is throwaway memory that the kernel uses for specific purposes for short periods of time. For example, it is used
 for garbage collection, and for writing to Flash, and as temporary storage during file lookups.

--- a/docs/kernel/general/standalone.md
+++ b/docs/kernel/general/standalone.md
@@ -23,16 +23,16 @@ First, copy this file to `src/userspace/build.cfg` for a basic build configurati
     # Clean up previous build, set up for this one
     rm out/
     mkdir out/bin/
-    
+
     # /bin/
     asm bin/init.asm out/bin/init
-    
+
     # Clean up
     rm out/bin/init.sym out/bin/init.lst
-    
+
     fscreate out/
 
-You should read the [build tool docs](https://github.com/SirCmpwn/KnightOS/tree/master/docs/build). This configuraiton
+You should read the [build tool docs](https://github.com/KnightSoft/KnightOS/tree/master/docs/build). This configuraiton
 will set up your userspace in a similar way to KnightOS - it will create the root of the on-calc filesystem in
 `src/userspace/out/` and create a filesystem based on it with `fscreate out/`. You then need to create the init program.
 This build configuration expects it to be in `src/userspace/bin/init.asm`. Create this file, and populate it with this:
@@ -47,16 +47,16 @@ This build configuration expects it to be in `src/userspace/bin/init.asm`. Creat
     ; Program
     .org 0
         jr start
-        
+
     start:
         ; Boot status codes
         or a ; cp 0
         ret nz
-        
+
         ; Handle boot up
-        
+
         ; ...
-        
+
         ; Temporary code so you know everything worked
         ; Replace this with proper initialization code
         call getLcdLock
@@ -66,9 +66,9 @@ This build configuration expects it to be in `src/userspace/bin/init.asm`. Creat
         ld b, 5
         call putSpriteOR
         call fastCopy
-        
+
         jr $
-        
+
     sprite:
         .db %01010000
         .db %01010000
@@ -78,7 +78,7 @@ This build configuration expects it to be in `src/userspace/bin/init.asm`. Creat
 
 This simile init program will just put a smiley face on the screen so you know that you've set everything up properly.
 You should replace this with proper initialization code. For inspiration, you might look to the KnightOS init program,
-whose source code is [here](https://github.com/SirCmpwn/KnightOS/blob/master/src/userspace/bin/init.asm).
+whose source code is [here](https://github.com/KnightSoft/KnightOS/blob/master/src/userspace/bin/init.asm).
 
 The kernel will run `/bin/init` after boot under certain conditions, with a status code based on those conditions. The
 A register always contains the status code, and is set to 0 when booting up normally. You should be able to just skip
@@ -87,7 +87,7 @@ all of these unless you need them at some point.
 Once you've added your init program, you should be able to compile and boot up your OS. Run `build --verbose --all` from
 the `build/` directory to build, like you would with KnightOS.
 
-You may have interest in [KnightOS-deriv](https://github.com/SirCmpwn/KnightOS-Deriv), which is a simple example operating
+You may have interest in [KnightOS-deriv](https://github.com/KnightSoft/KnightOS-Deriv), which is a simple example operating
 system based on the KnightOS kernel. It is likely to use an outdated kernel, however, so it is advised that you follow the
 above steps manually and simply use -deriv as a reference.
 

--- a/docs/kernel/routines/filesystem.md
+++ b/docs/kernel/routines/filesystem.md
@@ -27,7 +27,7 @@ garbage collection is complete.
 * [streamSeekToStart](#streamSeekToStart)
 
 The source for these routines may be found in
-[src/kernel/00/knighfs.asm](https://github.com/SirCmpwn/KnightOS/blob/master/src/kernel/00/knightfs.asm).
+[src/kernel/00/knighfs.asm](https://github.com/KnightSoft/KnightOS/blob/master/src/kernel/00/knightfs.asm).
 
 ## closeStream
 

--- a/docs/kernel/routines/flash.md
+++ b/docs/kernel/routines/flash.md
@@ -20,10 +20,10 @@ routines will work properly with flash locked.
 * [writeFlashByte](#writeflashbyte)
 
 The source for these routines may be found in
-[src/kernel/00/flash.asm](https://github.com/SirCmpwn/KnightOS/blob/master/src/kernel/00/flash.asm).
+[src/kernel/00/flash.asm](https://github.com/KnightSoft/KnightOS/blob/master/src/kernel/00/flash.asm).
 
 The exception is unlockFlash and lockFlash, which may be found in
-[src/kernel/00/util.asm](https://github.com/SirCmpwn/KnightOS/blob/master/src/kernel/00/util.asm).
+[src/kernel/00/util.asm](https://github.com/KnightSoft/KnightOS/blob/master/src/kernel/00/util.asm).
 
 ## copyFlashPage
 

--- a/docs/kernel/routines/general.md
+++ b/docs/kernel/routines/general.md
@@ -24,12 +24,12 @@ tasks.
 * [sub16from32](#sub16from32)
 * [setClock](#setclock)
 
-The code for these routines may be found in 
-[src/kernel/00/util.asm](https://github.com/SirCmpwn/KnightOS/blob/master/src/kernel/00/util.asm),
+The code for these routines may be found in
+[src/kernel/00/util.asm](https://github.com/KnightSoft/KnightOS/blob/master/src/kernel/00/util.asm),
 and in
-[src/kernel/00/time.asm](https://github.com/SirCmpwn/KnightOS/blob/master/src/kernel/00/time.asm),
+[src/kernel/00/time.asm](https://github.com/KnightSoft/KnightOS/blob/master/src/kernel/00/time.asm),
 and in
-[src/kernel/00/boot.asm](https://github.com/SirCmpwn/KnightOS/blob/master/src/kernel/00/boot.asm).
+[src/kernel/00/boot.asm](https://github.com/KnightSoft/KnightOS/blob/master/src/kernel/00/boot.asm).
 
 ## boot
 
@@ -251,7 +251,7 @@ Gets the boot code version string and loads it into memory.
 *Notes*
 
 You should call
-[freeMem](https://github.com/SirCmpwn/KnightOS/blob/master/docs/kernel/routines/memory.md#freemem)
+[freeMem](https://github.com/KnightSoft/KnightOS/blob/master/docs/kernel/routines/memory.md#freemem)
 when you are done with the string to free memory.
 
 This assumes that the string is at 0xF of the boot page, which is true for all

--- a/docs/kernel/routines/keyboard.md
+++ b/docs/kernel/routines/keyboard.md
@@ -2,8 +2,8 @@
 
 The kernel provides several routines for interfacing with the keyboard.
 
-*Note*: An include file is provided in 
-[inc/keys.inc](https://github.com/SirCmpwn/KnightOS/blob/master/inc/keys.inc) that
+*Note*: An include file is provided in
+[inc/keys.inc](https://github.com/KnightSoft/KnightOS/blob/master/inc/keys.inc) that
 includes all key codes used by the kernel.
 
 * [flushKeys](#flushkeys)
@@ -11,7 +11,7 @@ includes all key codes used by the kernel.
 * [waitKey](#waitkey)
 
 The code for these routines may be found in
-[src/kernel/00/keyboard.asm](https://github.com/SirCmpwn/KnightOS/blob/master/src/kernel/00/keyboard.asm).
+[src/kernel/00/keyboard.asm](https://github.com/KnightSoft/KnightOS/blob/master/src/kernel/00/keyboard.asm).
 
 # flushKeys
 

--- a/docs/kernel/routines/libraries.md
+++ b/docs/kernel/routines/libraries.md
@@ -2,8 +2,8 @@
 
 The kernel provides only one routine related to libraries.
 
-The code for these routines may be found in 
-[src/kernel/00/libraries.asm](https://github.com/SirCmpwn/KnightOS/blob/master/src/kernel/00/libraries.asm).
+The code for these routines may be found in
+[src/kernel/00/libraries.asm](https://github.com/KnightSoft/KnightOS/blob/master/src/kernel/00/libraries.asm).
 
 ## loadLibrary
 

--- a/docs/kernel/routines/memory.md
+++ b/docs/kernel/routines/memory.md
@@ -9,8 +9,8 @@ Several routines are also provided for manipulating pre-allocated memory.
 * [free](#free)
 * [memSeekToStart](#memseektostart)
 
-The code for these routines may be found in 
-[src/kernel/00/memory.asm](https://github.com/SirCmpwn/KnightOS/blob/master/src/kernel/00/memory.asm).
+The code for these routines may be found in
+[src/kernel/00/memory.asm](https://github.com/KnightSoft/KnightOS/blob/master/src/kernel/00/memory.asm).
 
 ## malloc
 

--- a/docs/kernel/routines/threads.md
+++ b/docs/kernel/routines/threads.md
@@ -15,7 +15,7 @@ The kernel provides a number of routines for creating, manipulating, and killing
 * [suspendCurrentThread](#suspendcurrentthread)
 
 The code for these routines may be found in
-[src/kernel/00/thread.asm](https://github.com/SirCmpwn/KnightOS/blob/master/src/kernel/00/thread.asm).
+[src/kernel/00/thread.asm](https://github.com/KnightSoft/KnightOS/blob/master/src/kernel/00/thread.asm).
 
 ## getCurrentThreadId
 

--- a/docs/libs/applib.md
+++ b/docs/libs/applib.md
@@ -4,7 +4,7 @@ applib provides several features specific to KnightOS, including access to the C
 well as routines for providing UIs based on the standard KnightOS UI.
 
 The source for applib may be found in
-[src/userspace/lib/applib/](https://github.com/SirCmpwn/KnightOS/tree/master/src/userspace/lib/applib).
+[src/userspace/lib/applib/](https://github.com/KnightSoft/KnightOS/tree/master/src/userspace/lib/applib).
 
 If you are interested in writing applications that use the UI framework, you should consider reading the UI
 application tutorial. (TODO)

--- a/docs/libs/libtext.md
+++ b/docs/libs/libtext.md
@@ -3,7 +3,7 @@
 libtext is a library for graphically drawing text on an LCD buffer. It is located at `/lib/libtext` on a normal KnightOS installation.
 
 The source for libtext may be found in
-[src/userspace/lib/libtext/](https://github.com/SirCmpwn/KnightOS/tree/master/src/userspace/lib/libtext).
+[src/userspace/lib/libtext/](https://github.com/KnightSoft/KnightOS/tree/master/src/userspace/lib/libtext).
 
 libtext uses the Windows-1252 character set, which was selected as the best 8-bit character set with international
 support.


### PR DESCRIPTION
All the docs' urls pointed to SirCmpwn/KnightOS; the new, correct
location for the docs is KnightSoft/KnightOS.

Also, fixed a typo that was really annoying me in README.md.

My editor has additionally automatically corrected some trailing whitespaces in the relevant sources.
