### PR TITLE
Fix issue #26, remove dummy time string from Castle

### DIFF
--- a/src/userspace/bin/castle/graphics.asm
+++ b/src/userspace/bin/castle/graphics.asm
@@ -499,5 +499,7 @@ configPath:
     .db "/etc/castle.config", 0
 naString:
     .db lang_nonApp, 0
+#ifdef CLOCK
 dummyTimeString:
     .db "12:00 AM", 0
+#endif


### PR DESCRIPTION
Most of the time code had already been excluded.  The only thing
left was the actual string.
