### PR TITLE
Added pt_pt translation

### DIFF
--- a/lang/pt_pt/castle.config.lang
+++ b/lang/pt_pt/castle.config.lang
@@ -1,0 +1,18 @@
+; Portuguese language file for /etc/castle.config
+
+; Text
+#define lang_graph "Gráfico"
+#define lang_math "Matemática"
+#define lang_blockDude "Block Dude"
+#define lang_textEditor "Editor de Texto"
+#define lang_calendar "Calendário"
+#define lang_fileBrowser "Ficheiros"
+#define lang_matrixEditor "Editor de Matrizes"
+#define lang_connectToPC "Ligação ao PC"
+#define lang_settings "Definições"
+#define lang_terminal "Terminal"
+
+; Testing
+#define lang_hello "Hello, world!"
+#define lang_demo "Demo"
+#define lang_countingTest "Demo de Contagem"

--- a/lang/pt_pt/castle.lang
+++ b/lang/pt_pt/castle.lang
@@ -1,0 +1,32 @@
+; Portuguese language file for /bin/castle
+
+; Text
+#define lang_more "Mais"
+#define lang_running "A Correr"
+#define lang_menu "Menu"
+#define lang_back "Voltar"
+#define lang_options "Opções"
+#define lang_addToCastle "Adicionar ao Castelo"
+#define lang_removeFromCastle "Remover do Castelo"
+#define lang_sleep "Suspender"
+#define lang_shutDown "Desligar"
+#define lang_restart "Reiniciar"
+#define lang_confirmShutdown "Tem a certeza?\nDados por guardar\nserão perdidos."
+#define lang_yes "Sim"
+#define lang_no "Não"
+#define lang_noPrograms "Nenhum programa instalado!"
+#define lang_nonApp "[n/a]"
+
+; Text locations
+; First nibble is X, second nibble is Y
+#define lang_more_position $093A
+#define lang_menu_position $253A
+#define lang_running_position $3B3A
+#define lang_sleep_position $2126
+#define lang_shutdown_position $212C
+#define lang_restart_position $2132
+#define lang_areYouSure_position $1A12
+#define lang_unsavedData_position $1418
+#define lang_mayBeLost_position $241E
+#define lang_yes_position $2C25
+#define lang_no_position $2C2B

--- a/lang/pt_pt/count.lang
+++ b/lang/pt_pt/count.lang
@@ -1,0 +1,6 @@
+; Portuguese language file for /etc/castle.config
+
+; Text
+#define lang_description "Demo de Contagem"
+#define lang_hello "Prima [Clear] para sair."
+#define lang_windowTitle "Demo de Contagem"

--- a/lang/pt_pt/gfxdemo.lang
+++ b/lang/pt_pt/gfxdemo.lang
@@ -1,0 +1,6 @@
+; Portuguese language file for /bin/demo
+
+; Text
+#define lang_description "Demo"
+#define lang_exitString "Prima [Clear] para sair."
+#define lang_windowTitle "Demo"

--- a/lang/pt_pt/hello.lang
+++ b/lang/pt_pt/hello.lang
@@ -1,0 +1,6 @@
+; Portuguese language file for /bin/hello
+
+; Text
+#define lang_description "Hello world"
+#define lang_helloString "Hello, world!\nPrima [Clear] para sair."
+#define lang_windowTitle "Hello world"

--- a/lang/pt_pt/terminal.lang
+++ b/lang/pt_pt/terminal.lang
@@ -1,0 +1,7 @@
+; Portuguese language file for /bin/terminal
+
+; Text
+#define lang_description "Terminal"
+#define lang_windowTitle "Terminal"
+#define lang_commandNotFound "Comando não encontrado\n"
+#define lang_launchError "Erro"

--- a/lang/pt_pt/threadlist.lang
+++ b/lang/pt_pt/threadlist.lang
@@ -1,0 +1,15 @@
+; Portuguese language file for /bin/threadlist
+
+; Text
+#define lang_str_castle "Castelo"
+#define lang_str_options "Opções"
+#define lang_str_runningPrograms "Programas em Execução"
+#define lang_str_noPrograms "Não existem programas em\nexecução!"
+#define lang_str_forceQuit "Terminar"
+
+; Positions
+.equ lang_forceQuit_position 61 * 256 + 50
+.equ lang_runningPrograms_position 1 * 256 + 4
+.equ lang_options_position 64 * 256 + 58
+.equ lang_castle_position 9 * 256 + 58
+.equ lang_noPrograms_position (1 << 8) + 12

--- a/lang/pt_pt/todo.lang
+++ b/lang/pt_pt/todo.lang
@@ -1,0 +1,4 @@
+; Portuguese language file for /bin/todo
+
+; Text
+#define lang_todo "Esta característica ainda\nnão foi implementada.\nPrima uma tecla para sair."

--- a/packages/threadlist/threadlist.asm
+++ b/packages/threadlist/threadlist.asm
@@ -7,20 +7,20 @@
 start:
     call getLcdLock
     call getKeypadLock
-    
+
     call allocScreenBuffer
 redraw:
     kcall(drawInterface)
     kcall(drawThreads)
     ld a, (totalThreads)
     kjp(z, noThreads)
-    
+
     ld ix, threadTable
 mainLoop:
     call fastCopy
     call flushKeys
     call waitKey
-    
+
     cp kClear
     kjp(z, launchCastle)
     cp kYEqu
@@ -37,9 +37,9 @@ mainLoop:
     kjp(z, doKill)
     cp kGraph
     kjp(z, doOptions)
-    
+
     jr mainLoop
-    
+
 doUp:
     ld a, e
     cp 12
@@ -72,7 +72,7 @@ _:      pop ix
     pop de
     pop hl
     jr mainLoop
-    
+
 doDown:
     kld(a, (totalThreads))
     dec a
@@ -113,7 +113,7 @@ _:      pop ix
     pop de
     pop hl
     kjp(mainLoop)
-    
+
 doSelect:
     call flushKeys
     di
@@ -122,14 +122,14 @@ doSelect:
     ld (hwLockKeypad), a
     call resumeThread
     jp killCurrentThread
-    
+
 doKill:
     di
     ld a, (ix)
     call killThread
     ei
     kjp(redraw)
-    
+
 doOptions:
     kcall(drawOptions)
     call fastCopy
@@ -151,26 +151,27 @@ launchCastle:
     di
     call launchProgram
     jp killCurrentThread
-    
+
 noThreads:
     kcall(drawInterface)
+    ld b, 0
     ld de, lang_noPrograms_position
     kld(hl, noProgramsStr)
     call drawStr
-    
+
     call fastCopy
-    
+
 _:  call flushKeys
     call waitKey
-    
+
     cp kClear
     jr z, _
     cp kYEqu
     jr nz, -_
-    
+
 _:  call flushKeys
     jr launchCastle
-    
+
 drawThreads:
     xor a
     kld((totalThreads), a)
@@ -203,13 +204,13 @@ skipThread:
     ld a, 6 \ add a, e \ ld e, a
     ld a, 8 \ add a, l \ ld l, a
     djnz drawThreads_loop
-    
+
     kld(hl, selectionIndicatorSprite)
     ld b, 5
     ld de, 1 * 256 + 12
     call PutSpriteOR
     ret
-    
+
 drawInterface:
     call clearBuffer
     ; Castle top
@@ -227,52 +228,52 @@ _:    ld a, 8
     add a, d
     ld d, a
     djnz -_
-    
+
     kld(hl, hotkeyLeftSprite)
     ld b, 8
     ld de, 0x0038
     call putSpriteOR
-    
+
     kld(hl, hotkeyRightSprite)
     ld de, 0x5838
     call putSpriteOR
-    
+
     kld(hl, hotkeyArrowLeftSprite)
     ld b, 5
     ld de, 0x003A
     call putSpriteOR
-    
+
     kld(hl, hotkeyPlusSprite)
     ld b, 5
     ld de, 0x5A3A
     call putSpriteOR
-    
+
     kld(hl, backStr)
     ld de, lang_castle_position
     call drawStr
-    
+
     kld(hl, optionsStr)
     ld de, lang_options_position
     call drawStr
-        
+
     kld(hl, runningProgramsStr)
     ld de, lang_runningPrograms_position
     call drawStr
-    
+
     ld hl, 0x000A
     ld de, 0x5F0A
     call drawLine
     ret
-    
+
 drawOptions:
     kld(hl, hotkeyPlusSprite)
     ld de, 0x5A3A
     call putSpriteXOR
-    
+
     kld(hl, hotkeyArrowUpSprite)
     ld de, 0x593A
     call putSpriteOR
-    
+
     ld e, 55 - (61 - (lang_forceQuit_position >> 8))
     ld l, 48
     ld c, 96 - 54 + (61 - (lang_forceQuit_position >> 8))
@@ -291,22 +292,22 @@ drawOptions:
     ld a, 87
     ld l, 57
     call setPixel
-    
+
     kld(hl, forceQuitStr)
     ld de, lang_forceQuit_position
     call drawStr
-    
+
     kld(hl, selectionIndicatorSprite)
     ld b, 5
     ld de, ((57  - (61 - (lang_forceQuit_position >> 8))) << 8) + 50
     call putSpriteOR
     ret
-    
+
 castleTopSprite: ; 8x3
     .db 0b11110000
     .db 0b10010000
     .db 0b10011111
-    
+
 hotkeyLeftSprite: ; 8x8
     .db 0b01111100
     .db 0b10000010
@@ -316,7 +317,7 @@ hotkeyLeftSprite: ; 8x8
     .db 0b00000001
     .db 0b00000001
     .db 0b10000010
-    
+
 hotkeyRightSprite: ; 8x8
     .db 0b00111110
     .db 0b01000001
@@ -326,35 +327,35 @@ hotkeyRightSprite: ; 8x8
     .db 0b10000000
     .db 0b10000000
     .db 0b01000001
-    
+
 hotkeyPlusSprite: ; 8x5
     .db 0b00100000
     .db 0b00100000
     .db 0b11111000
     .db 0b00100000
     .db 0b00100000
-    
+
 hotkeyArrowLeftSprite: ; 8x5
     .db 0b0010000
     .db 0b0100000
     .db 0b1111100
     .db 0b0100000
     .db 0b0010000
-    
+
 hotkeyArrowUpSprite: ; 8x5
     .db 0b0010000
     .db 0b0111000
     .db 0b1010100
     .db 0b0010000
     .db 0b0010000
-    
+
 selectionIndicatorSprite: ; 8x5
     .db 0b10000000
     .db 0b11000000
     .db 0b11100000
     .db 0b11000000
     .db 0b10000000
-    
+
 backStr:
     .db lang_str_castle, 0
 optionsStr:
@@ -365,9 +366,9 @@ noProgramsStr:
     .db lang_str_noPrograms, 0
 forceQuitStr:
     .db lang_str_forceQuit, 0
-    
+
 totalThreads:
     .db 0
-    
+
 castlePath:
     .db "/bin/castle", 0


### PR DESCRIPTION
The only line I noticed that doesn't fit is `lang_confirmShutdown` in the file `castle.lang`, 2 characters are drawn out of the box. I can't think of a smaller sentence for it.
