### PR TITLE
Save build artifacts after each build

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -19,12 +19,12 @@ sources:
 environment:
   project: KnightOS
 artifacts:
-  - bin/KnightOS-TI73.8xu
-  - bin/KnightOS-TI83p.8xu
-  - bin/KnightOS-TI83pSE.8xu
-  - bin/KnightOS-TI84p.8xu
-  - bin/KnightOS-TI84pSE.8xu
-  - bin/KnightOS-TI84pCSE.8xu
+  - KnightOS/bin/KnightOS-TI73.8xu
+  - KnightOS/bin/KnightOS-TI83p.8xu
+  - KnightOS/bin/KnightOS-TI83pSE.8xu
+  - KnightOS/bin/KnightOS-TI84p.8xu
+  - KnightOS/bin/KnightOS-TI84pSE.8xu
+  - KnightOS/bin/KnightOS-TI84pCSE.8cu
 tasks:
   - ti73: |
       cd ${project}

--- a/.build.yml
+++ b/.build.yml
@@ -19,7 +19,7 @@ sources:
 environment:
   project: KnightOS
 artifacts:
-  - KnightOS/out/KnightOS-TI73.8xu
+  - KnightOS/out/KnightOS-TI73.73u
   - KnightOS/out/KnightOS-TI83p.8xu
   - KnightOS/out/KnightOS-TI83pSE.8xu
   - KnightOS/out/KnightOS-TI84p.8xu
@@ -27,38 +27,38 @@ artifacts:
   - KnightOS/out/KnightOS-TI84pCSE.8cu
 tasks:
   - ti73: |
-    cd ${project}
-    mkdir out
-    knightos init --platform=TI73
-    make upgrade
-    cp bin/KnightOS-TI73.8xu out/
+      cd ${project}
+      mkdir out
+      knightos init --platform=TI73
+      make upgrade
+      cp bin/KnightOS-TI73.73u out/
   - ti83p: |
-    cd ${project}
-    knightos init --platform=TI83p
-    make clean
-    make upgrade
-    cp bin/KnightOS-TI83p.8xu out/
+      cd ${project}
+      knightos init --platform=TI83p
+      make clean
+      make upgrade
+      cp bin/KnightOS-TI83p.8xu out/
   - ti83pse: |
-    cd ${project}
-    knightos init --platform=TI83pSE
-    make clean
-    make upgrade
-    cp bin/KnightOS-TI83pSE.8xu out/
+      cd ${project}
+      knightos init --platform=TI83pSE
+      make clean
+      make upgrade
+      cp bin/KnightOS-TI83pSE.8xu out/
   - ti84p: |
-    cd ${project}
-    knightos init --platform=TI84p
-    make clean
-    make upgrade
-    cp bin/KnightOS-TI84p.8xu out/
+      cd ${project}
+      knightos init --platform=TI84p
+      make clean
+      make upgrade
+      cp bin/KnightOS-TI84p.8xu out/
   - ti84pse: |
-    cd ${project}
-    knightos init --platform=TI84pSE
-    make clean
-    make upgrade
-    cp bin/KnightOS-TI84pSE.8xu out/
+      cd ${project}
+      knightos init --platform=TI84pSE
+      make clean
+      make upgrade
+      cp bin/KnightOS-TI84pSE.8xu out/
   - ti84pcse: |
-    cd ${project}
-    knightos init --platform=TI84pCSE
-    make clean
-    make upgrade
-    cp bin/KnightOS-TI84pCSE.8cu out/
+      cd ${project}
+      knightos init --platform=TI84pCSE
+      make clean
+      make upgrade
+      cp bin/KnightOS-TI84pCSE.8cu out/

--- a/.build.yml
+++ b/.build.yml
@@ -19,39 +19,46 @@ sources:
 environment:
   project: KnightOS
 artifacts:
-  - KnightOS/bin/KnightOS-TI73.8xu
-  - KnightOS/bin/KnightOS-TI83p.8xu
-  - KnightOS/bin/KnightOS-TI83pSE.8xu
-  - KnightOS/bin/KnightOS-TI84p.8xu
-  - KnightOS/bin/KnightOS-TI84pSE.8xu
-  - KnightOS/bin/KnightOS-TI84pCSE.8cu
+  - KnightOS/out/KnightOS-TI73.8xu
+  - KnightOS/out/KnightOS-TI83p.8xu
+  - KnightOS/out/KnightOS-TI83pSE.8xu
+  - KnightOS/out/KnightOS-TI84p.8xu
+  - KnightOS/out/KnightOS-TI84pSE.8xu
+  - KnightOS/out/KnightOS-TI84pCSE.8cu
 tasks:
   - ti73: |
-      cd ${project}
-      knightos init --platform=TI73
-      make upgrade
+    cd ${project}
+    mkdir out
+    knightos init --platform=TI73
+    make upgrade
+    cp bin/KnightOS-TI73.8xu out/
   - ti83p: |
-      cd ${project}
-      knightos init --platform=TI83p
-      make clean
-      make upgrade
+    cd ${project}
+    knightos init --platform=TI83p
+    make clean
+    make upgrade
+    cp bin/KnightOS-TI83p.8xu out/
   - ti83pse: |
-      cd ${project}
-      knightos init --platform=TI83pSE
-      make clean
-      make upgrade
+    cd ${project}
+    knightos init --platform=TI83pSE
+    make clean
+    make upgrade
+    cp bin/KnightOS-TI83pSE.8xu out/
   - ti84p: |
-      cd ${project}
-      knightos init --platform=TI84p
-      make clean
-      make upgrade
+    cd ${project}
+    knightos init --platform=TI84p
+    make clean
+    make upgrade
+    cp bin/KnightOS-TI84p.8xu out/
   - ti84pse: |
-      cd ${project}
-      knightos init --platform=TI84pSE
-      make clean
-      make upgrade
+    cd ${project}
+    knightos init --platform=TI84pSE
+    make clean
+    make upgrade
+    cp bin/KnightOS-TI84pSE.8xu out/
   - ti84pcse: |
-      cd ${project}
-      knightos init --platform=TI84pCSE
-      make clean
-      make upgrade
+    cd ${project}
+    knightos init --platform=TI84pCSE
+    make clean
+    make upgrade
+    cp bin/KnightOS-TI84pCSE.8cu out/

--- a/.build.yml
+++ b/.build.yml
@@ -18,6 +18,13 @@ sources:
   - https://github.com/KnightOS/KnightOS
 environment:
   project: KnightOS
+artifacts:
+  - bin/KnightOS-TI73.8xu
+  - bin/KnightOS-TI83p.8xu
+  - bin/KnightOS-TI83pSE.8xu
+  - bin/KnightOS-TI84p.8xu
+  - bin/KnightOS-TI84pSE.8xu
+  - bin/KnightOS-TI84pCSE.8xu
 tasks:
   - ti73: |
       cd ${project}


### PR DESCRIPTION
because it'll allow us to fix the `Browse Other Versions` link on https://knightos.org/downloads :smile: 