### PR TITLE
Removed the  -c option from kimg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(OUT)exploit.bin: exploit/exploit.asm
 
 $(SHARE)icons/copyright.img: config/copyright.png
 	mkdir -p $(SHARE)icons
-	kimg -c config/copyright.png $(SHARE)icons/copyright.img
+	kimg  config/copyright.png $(SHARE)icons/copyright.img
 
 $(ETC)LICENSE: LICENSE
 	mkdir -p $(ETC)


### PR DESCRIPTION
Currently if you try to use the make file as is **kimg** will throw an "unrecognized argument: -c" and halt the makefile. Removing this offending parameter fixes the issue. 
Tested on Ubuntu 20.04